### PR TITLE
adds the package.json, so npm can download as repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "simple-blog-ui",
+  "version": "0.0.1",
+  "description": "Simple blog UI",
+  "main": "./views/home.html",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vlad-saling/simple-blog-ui.git"
+  },
+  "keywords": [
+    "blog"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/vlad-saling/simple-blog-ui/issues"
+  },
+  "homepage": "https://github.com/vlad-saling/simple-blog-ui#readme"
+}


### PR DESCRIPTION
Hi @vlad-saling,
I created a `package.json` file, so this repository can be installed by `npm`, unfortunately npm does not support repositories without `package.json`.

Can you please merge it to your repo, if possible?